### PR TITLE
Minor enhancement: Better handling of the IDL session exiting

### DIFF
--- a/pidly.py
+++ b/pidly.py
@@ -1,4 +1,4 @@
-"""pIDLy 0.2.4+: IDL within Python.
+﻿"""pIDLy 0.2.4+: IDL within Python.
 
 Control ITT's IDL (Interactive Data Language) from within Python.
 
@@ -744,6 +744,11 @@ class IDL(pexpect.spawn):
                     print self.before,
                     sys.stdout.flush()
                 self.interact(show_prompt=False)
+                break
+            except pexpect.EOF, err:
+                import sys
+                sys.stderr.write('ERROR: IDL session appears to have exited or otherwise closed\n')
+                raise IOError, "IDL session appears to have exited or otherwise closed."
                 break
             new_line = self.before.replace('\r', '')
             if new_line.startswith('% Stop encountered:'):


### PR DESCRIPTION
If the IDL session exits, this detects the pexpect.EOF exception thrown by pexpect, prints to stdout an informative message that the IDL session has exited, and passes a regular IOError exception back up the call stack. 

This allows better/more graceful pIDLy control for the case of an IDL session that
consists of e.g. running some pre-existing procedure that does some
particular calculation and then exits.

Thanks for a useful and very easy to use tool!
